### PR TITLE
Assert da linha 61 está incorreto.

### DIFF
--- a/src/test/java/br/com/alura/leilao/service/GeradorDePagamentoTest.java
+++ b/src/test/java/br/com/alura/leilao/service/GeradorDePagamentoTest.java
@@ -58,7 +58,7 @@ class GeradorDePagamentoTest {
 		
 		Pagamento pagamento = captor.getValue();
 		
-		Assert.assertEquals(LocalDate.now().plusDays(1), 
+		Assert.assertEquals(LocalDate.of(2020, 12, 7).plusDays(1), 
 				pagamento.getVencimento());
 		Assert.assertEquals(vencedor.getValor(), pagamento.getValor());
 		Assert.assertFalse(pagamento.getPago());


### PR DESCRIPTION
O chamado para LocalDate.now() só funcionaria para a data da gravação da aula e como as alterações nos outros métodos, deveria ser um valor mockado, com o LocalDate.of(2020, 12, 7), do contrário é impossível o teste passar, pois a data em hipótese alguma é a esperada, ou seja, o dia seguinte a data de gravação da aula.

Inclusive imagino que isso mereça uma errada em uma página do curso. Sugeri uma alteração na página de download do arquivo rar da 5ª aula com a explicação.